### PR TITLE
Updated timings, fixed sayMinutes.

### DIFF
--- a/Information_README.txt
+++ b/Information_README.txt
@@ -50,6 +50,9 @@ _HERTZ is abrivated to _HZ
 IMPORTANT OTHER THINGS TO BE AWARE OF:
 all words (underscored or otherwise) are defined and not variables. As such they should be avoided as variable names.
 
+* Big Buddy Talker special consideration had to be taken for the Alphabets
+see the BBT_example_three_Alphabets example for more information.
 
 
+Big Buddy Talker default timing has changed to 850 milliseconds to account for a couple of the long words on the 3rd chip.  However most words work good with the original 700 milliseconds timings. Example BBT_example_two_compound_words has more information about how to change timings on the fly
 

--- a/New_Features.txt
+++ b/New_Features.txt
@@ -59,3 +59,6 @@ https://www.instructables.com/id/A-Talking-Sensor-Si7021-and-Little-Buddy-Talker
 
 V5.0.0 - May 2018 Updated to work with the Big Buddy Talker. (Works a bit different then previous models) 
 
+v5.0.7 - May 28, 2018 changed default timing for BBT to 850, corrected/fixxed sayMinute for BBT
+
+

--- a/examples/BBT_d1_mini_talking_clock/license.h
+++ b/examples/BBT_d1_mini_talking_clock/license.h
@@ -1,0 +1,20 @@
+/*
+
+Copyright (c) 2018 LeRoy Miller
+
+This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses>
+
+Change Log:
+ 
+*/

--- a/examples/BBT_example_two_compound_words/BBT_example_two_compound_words.ino
+++ b/examples/BBT_example_two_compound_words/BBT_example_two_compound_words.ino
@@ -30,6 +30,7 @@ This program is free software: you can redistribute it and/or modify
  *  Word timings can be set on the fly, see the code below.
  *  This does take some trial and error, but produces some nice effects.
  *  Copyright (c) 2018 LeRoy Miller
+ * Updated May 28, 2018 - LeRoy Miller
  */
  
 /* Big Buddy Talker Arduino UNO Hookup
@@ -87,17 +88,22 @@ Word100.say(_BUDDY);
   *
   * Timings are tricky and take some trial and error
   * to get right.
+  * 
+  * Big Buddy Talker has a default timing of 850, which is too
+  * long for most words, but needed for the few really long words/sentences
+  * Under most conditions a timing of 700 works pretty well, but does
+  * sound a little robotic.
   */
   
   Word100.setDelay(475);
   Word100.say(_COUNTER);
-  Word100.setDelay(700); //default timing for most words
+  Word100.setDelay(700); //timing that works for most words
   Word100.say(_CLOCKWISE);
 
 //lighting
  Word100.setDelay(450);
  Word100.say(_LIGHT);
- Word100.setDelay(700); //default timing for most words
+ Word100.setDelay(700); //timing that works for most words
  Word100.say(_ING);
 
 //micrometers

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Word100 Library
-version=5.0.6
+version=5.0.7
 author=LeRoy Miller
 maintainer=LeRoy Miller <kd8bxp@aol.com>
 sentence=Library for 100+ Word Shield and LBT 

--- a/src/Word100BBT.cpp
+++ b/src/Word100BBT.cpp
@@ -31,16 +31,10 @@ This program is free software: you can redistribute it and/or modify
 May 4, 2018 Updated for the Big Buddy Talker, LeRoy Miller (2018 (c))
 May 12, 2018 sayNumber functions (minutes,hours) all working again.
 	Made small change to how setAMPM work, but nothing that effects the sketches
-
+May 28, 2018 Updated timing to 850, and fixed sayMinute issues
 */
 
-// Connect pin#13 (SCLK) To S2 on AP23 
-// Connect pin#11 (DATOUT) To S3 on AP23 
-// Connect pin#13 (SCLK) To S2 on AP23 
-// Connect pin#10 (CS) To S1 on AP23
-// GPIO 9 = STOP
-// DO from Ap23 optional S4 - Not used here
-// ** Add stop bit so that MCU knows then  the chip has stopped talking.  OUT1 is what you'll want to use
+
  
 #define _PLAY_ 0x98
 #define _RAMPUP 0xA8 //COUT ramp up - this value never changes
@@ -53,7 +47,7 @@ _cs[1] = cs2;
 _cs[2] = cs3;
 _cs[3] = cs4;
 Word100bbt::setAMPM(1);
-Word100bbt:setDelay(700); //default delay is about 700 milliseconds
+Word100bbt:setDelay(850); //default delay is about 850 milliseconds
 }
 
 void Word100bbt::begin() {
@@ -94,7 +88,7 @@ void Word100bbt::say(int value, int pin)    // Calling this function reads words
 int Word100bbt::sayMinutes(long number) {
 if (number == 0) {
     
-  Word100bbt::say(_ZERO);   //special case for zero
+  //Word100bbt::say(_ZERO);   //special case for zero
    return 0;
 }
 
@@ -108,9 +102,9 @@ if (number == 0) {
    if (_tens > 1) {
       	 Word100bbt::say(_sayDecades[_tens][0],_sayDecades[_tens][1]);
 	     _period = _period - _tens*TEN; } else {
-           Word100bbt::say(_ZERO);
+           //Word100bbt::say(_ZERO);
 		       }
-          
+      if (number < 10) { Word100bbt::say(_ZERO); }    
    if (_period == 0)  { return 0; } else {
          Word100bbt::say(_sayDigits[_period][0],_sayDigits[_period][1]);
 			}


### PR DESCRIPTION
Default timing for BBT is 850, fixed issue found with sayMinutes and BBT
updated d1 mini talking time clock example for the BBT